### PR TITLE
Add Zip file upload, remove requirements for some steps, and update desc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # Upload to Sauce Labs
 
-Uploads a Bitrise produced iOS or Android build to the US West 1 Sauce Labs remote storage.
+Upload a Bitrise produced iOS or Android build to Sauce Labs [mobile app storage](https://docs.saucelabs.com/mobile-apps/app-storage/).
 
 Required fields for upload are:
 * sauce_username
 * sauce_access_key
-* sauce_app_name
 
 ## How to use this Step
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -5,7 +5,7 @@ app:
   envs:
     # If you want to share this step into a StepLib
     - BITRISE_STEP_ID: upload-to-sauce-labs
-    - BITRISE_STEP_VERSION: "0.0.2"
+    - BITRISE_STEP_VERSION: "0.1.0"
     - BITRISE_STEP_GIT_CLONE_URL: https://github.com/camseda/bitrise-step-upload-to-sauce-labs.git
     - MY_STEPLIB_REPO_FORK_GIT_URL: git@github.com:camseda/bitrise-step-upload-to-sauce-labs.git
 
@@ -26,14 +26,15 @@ workflows:
       - path::./:
           title: Sauce Labs Upload Step Test
           description: |
-            Uploads an IPA/APK/AAB file to Sauce Labs.
-            To test this, you need a Sauce Labs account with a valid username/access key and an IPA/APK/AAB path from which to upload.
+            Uploads an IPA/APK/AAB/ZIP file to Sauce Labs.
+            To test this, you need a Sauce Labs account with a valid username/access key and an IPA/APK/AAB/ZIP path from which to upload.
           run_if: true
           inputs:
             - sauce_username: $SAUCE_USERNAME
             - sauce_access_key: $SAUCE_ACCESS_KEY
             - sauce_app_name: $SAUCE_APP_NAME
             - artifact_path: $ARTIFACT_PATH
+            - data_center_url: $DATA_CENTER_URL
       - script:
           inputs:
             - content: |

--- a/step.sh
+++ b/step.sh
@@ -1,11 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-if [[ -z $sauce_app_name ]]; then
-  echo "SAUCE_APP_NAME environment variable must be set for this workflow!"
-  exit 1
-fi
-
 if [[ -z $artifact_path ]]; then
   artifact_path=$(if [[ $sauce_app_name =~ ".apk" ]]; then
     echo $BITRISE_APK_PATH;
@@ -13,16 +8,30 @@ if [[ -z $artifact_path ]]; then
     echo $BITRISE_AAB_PATH; 
   elif [[ $sauce_app_name =~ ".ipa" ]]; then
     echo $BITRISE_IPA_PATH;
+  elif [[ $sauce_app_name =~ ".zip" ]]; then
+    echo $BITRISE_XCARCHIVE_ZIP_PATH;
   else
-    echo "Your application name does not contain a valid extension (.apk, .aab, or .ipa).";
+    echo "Your application name does not contain a valid extension (.apk, .aab, .ipa, or .zip).";
     echo "Please update your sauce_app_name input value, or set your own artifact_path.";
     exit 1;
   fi)
 fi
 
-curl --location --request POST \
-  --url "https://api.us-west-1.saucelabs.com/v1/storage/upload" \
+if [[ -z $data_center_endpoint ]]; then
+  data_center_endpoint="https://api.us-west-1.saucelabs.com/v1/storage/upload"
+fi
+
+if [[ -z $sauce_app_name ]]; then
+  curl --location --request POST \
+  --url "$data_center_endpoint" \
   --user "$sauce_username:$sauce_access_key" \
   --form "payload=@$artifact_path"\
-  --form "name=$sauce_app_name" \
   --fail
+else
+  curl --location --request POST \
+    --url "$data_center_endpoint" \
+    --user "$sauce_username:$sauce_access_key" \
+    --form "payload=@$artifact_path"\
+    --form "name=$sauce_app_name" \
+    --fail
+fi

--- a/step.sh
+++ b/step.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
+if [[ -z $sauce_app_name ]]; then
+  echo "SAUCE_APP_NAME environment variable must be set for this workflow!"
+  exit 1
+fi
+
 if [[ -z $artifact_path ]]; then
   artifact_path=$(if [[ $sauce_app_name =~ ".apk" ]]; then
     echo $BITRISE_APK_PATH;

--- a/step.sh
+++ b/step.sh
@@ -26,17 +26,9 @@ if [[ -z $data_center_endpoint ]]; then
   data_center_endpoint="https://api.us-west-1.saucelabs.com/v1/storage/upload"
 fi
 
-if [[ -z $sauce_app_name ]]; then
-  curl --location --request POST \
+curl --location --request POST \
   --url "$data_center_endpoint" \
   --user "$sauce_username:$sauce_access_key" \
   --form "payload=@$artifact_path"\
+  --form "name=$sauce_app_name" \
   --fail
-else
-  curl --location --request POST \
-    --url "$data_center_endpoint" \
-    --user "$sauce_username:$sauce_access_key" \
-    --form "payload=@$artifact_path"\
-    --form "name=$sauce_app_name" \
-    --fail
-fi

--- a/step.yml
+++ b/step.yml
@@ -88,8 +88,8 @@ inputs:
       is_required: false
   - data_center_url:
     opts:
-      title: App storage URL containing the location of your data center
-      summary: Leave empty to use the US West data center.
+      title: Request / data center URL
+      summary: App storage URL containing the location of your data center
       description: |
         If using the ES East or Europe data center, provide the desired URL for the POST request.
         This step will default to US West (https://api.us-west-1.saucelabs.com/v1/storage/upload) otherwise.

--- a/step.yml
+++ b/step.yml
@@ -10,15 +10,20 @@
 title: |-
   Upload to Sauce Labs
 summary: |
-  Upload APK/AAB/IPA artifacts to Sauce Labs.
+  Upload an APK/AAB/IPA/ZIP artifact to Sauce Labs.
 description: |
-  Upload your build files to Sauce Labs for remote device testing.
-  Needs an APK, AAB, or IPA file, Sauce Labs username, access key, and custom file name.
+  Upload your build file to Sauce Labs for remote device testing.
+  Requires an APK, AAB, IPA, or ZIP file, Sauce Labs username, and access key.
+  You can optionally provide a custom file name, build path, or request url.
 
   Required fields are:
   - sauce_username
   - sauce_access_key
+
+  Optional fields are:
   - sauce_app_name
+  - artifact_path
+  - data_center_url
 website: https://github.com/camseda/bitrise-step-upload-to-sauce-labs
 source_code_url: https://github.com/camseda/bitrise-step-upload-to-sauce-labs
 support_url: https://github.com/camseda/bitrise-step-upload-to-sauce-labs/issues
@@ -37,12 +42,8 @@ run_if: ""
 deps:
   brew:
     - name: git
-    - name: wget
-    - name: jq
   apt_get:
     - name: git
-    - name: wget
-    - name: jq
 
 toolkit:
   bash:
@@ -71,14 +72,25 @@ inputs:
         This is translated to the File Name in Sauce Labs.
         Can be used to activate a specific app with the `filename` flag in your Capabilities
         rather than using the File ID automatically generated on upload - `storage:filename=<fileName>.<ext>`.
-        A JavaScript example would be: `caps['app'] = 'storage:filename=<file-name>.apk';`
-      is_required: true
+        A JavaScript example would be: `caps['app'] = 'storage:filename=TestApplication.apk';`
+
+        If `sauce_app_name` is not provided, Sauce Labs adds a filename based on the `artifact_path`.
+      is_required: false
   - artifact_path:
     opts:
-      title: The absolute APK, AAB, or IPA path
+      title: The absolute APK, AAB, IPA, or ZIP path
       summary: Leave empty to use an automatically generated artifact_path.
       description: |
-        Generated automatically based on the Sauce Lab application's name extension set above.
-        If you'd like to overwrite the 'artifact_path' for the cURL request, you can set the file path here (usually `$BITRISE_APK_PATH`, `$BITRISE_AAB_PATH`,
-        or `$BITRISE_IPA_PATH`).
+        Generated automatically based on the Sauce Lab application's name extension set in `sauce_app_name`.
+        If you'd like to set a custom 'artifact_path' for the cURL, you can set the file path here (usually `$BITRISE_APK_PATH`, `$BITRISE_AAB_PATH`, or `$BITRISE_IPA_PATH`).
+
+        If `sauce_app_name` is not supplied or if you're uploading a file in a format other than .apk, .aab, .ipa, or .zip, you will need to provide a value for `artifact_path`.
+      is_required: false
+  - data_center_url:
+    opts:
+      title: App storage URL containing the location of your data center
+      summary: Leave empty to use the US West data center.
+      description: |
+        If using the ES East or Europe data center, provide the desired URL for the POST request.
+        This step will default to US West (https://api.us-west-1.saucelabs.com/v1/storage/upload) otherwise.
       is_required: false

--- a/step.yml
+++ b/step.yml
@@ -13,15 +13,15 @@ summary: |
   Upload an APK/AAB/IPA/ZIP artifact to Sauce Labs.
 description: |
   Upload your build file to Sauce Labs for remote device testing.
-  Requires an APK, AAB, IPA, or ZIP file, Sauce Labs username, and access key.
-  You can optionally provide a custom file name, build path, or request url.
+  Requires an APK, AAB, IPA, or ZIP file within the workflow, Sauce Labs username, access key, and file name.
+  You can optionally provide a build path and request url.
 
   Required fields are:
   - sauce_username
   - sauce_access_key
+  - sauce_app_name
 
   Optional fields are:
-  - sauce_app_name
   - artifact_path
   - data_center_url
 website: https://github.com/camseda/bitrise-step-upload-to-sauce-labs
@@ -69,22 +69,21 @@ inputs:
       title: Sauce Labs App Name
       summary: Your Sauce Labs application name and extension.
       description: |
-        This is translated to the File Name in Sauce Labs.
-        Can be used to activate a specific app with the `filename` flag in your Capabilities
+        This is translated to the File Name in Sauce Labs (and must include the file extension). The extension is used to automatically set the `artifact_path`.
+
+        Sauce Lab's File Name can be used to activate a specific app with the `filename` flag in your Capabilities
         rather than using the File ID automatically generated on upload - `storage:filename=<fileName>.<ext>`.
         A JavaScript example would be: `caps['app'] = 'storage:filename=TestApplication.apk';`
-
-        If `sauce_app_name` is not provided, Sauce Labs adds a filename based on the `artifact_path`.
-      is_required: false
+      is_required: true
   - artifact_path:
     opts:
       title: The absolute APK, AAB, IPA, or ZIP path
       summary: Leave empty to use an automatically generated artifact_path.
       description: |
-        Generated automatically based on the Sauce Lab application's name extension set in `sauce_app_name`.
-        If you'd like to set a custom 'artifact_path' for the cURL, you can set the file path here (usually `$BITRISE_APK_PATH`, `$BITRISE_AAB_PATH`, or `$BITRISE_IPA_PATH`).
+        Generated automatically based on the Sauce Lab application's name set in `sauce_app_name`.
+        The extension will be used to gather the `BITRISE_APK_PATH`, `BITRISE_AAB_PATH`, `BITRISE_IPA_PATH`, or `BITRISE_XCARCHIVE_ZIP_PATH`.
 
-        If `sauce_app_name` is not supplied or if you're uploading a file in a format other than .apk, .aab, .ipa, or .zip, you will need to provide a value for `artifact_path`.
+        If you're uploading a file in a format other than .apk, .aab, .ipa, or .zip, you will need to provide a value for `artifact_path`.
       is_required: false
   - data_center_url:
     opts:


### PR DESCRIPTION
Updates the repo for general publishing to Bitrise.

- Removes the requirement for `sauce_app_name` to be provided
- Adds a custom var for `data_center_url`. This adheres to the data centers provided by Sauce [here](https://docs.saucelabs.com/basics/data-center-endpoints/)
- Adds a default for an iOS .zip file upload. This was taken from the `xcode-archive` step [here](https://github.com/bitrise-steplib/steps-xcode-archive/blob/master/step.yml#L488)
- Modified the script to work in ZIP, data center default, and not include `name` in curl if no value was given
- Modify descriptions of workflows, variables, etc.

To be done in follow up:
- Output var for the FileId returned by Sauce